### PR TITLE
jme3-alloc-native/build.gradle: added `bash` command to compileX86 task

### DIFF
--- a/jme3-alloc-native/build.gradle
+++ b/jme3-alloc-native/build.gradle
@@ -22,6 +22,7 @@ task copyNatives(type: Copy) {
 
 task compileX86() {
     String command = "bash";
+    final String[] chmod = new String[] { "chmod", "+rwx" };
     final String compileX86 = "./helper-scripts/compile-x86.sh";
     final String system = System.getProperty("os.name");
     
@@ -30,6 +31,7 @@ task compileX86() {
     }
     
     /* execute the shell script in a unix process that inheirt from the current environment */
+    Runtime.getRuntime().exec(new String[] { chmod[0], chmod[1], compileX86 });
     Runtime.getRuntime().exec(new String[] { command, compileX86 });
 }
 

--- a/jme3-alloc-native/build.gradle
+++ b/jme3-alloc-native/build.gradle
@@ -21,7 +21,11 @@ task copyNatives(type: Copy) {
 }
 
 task compileX86() {
-    Runtime.getRuntime().exec(new String[] {"./helper-scripts/compile-x86.sh"});
+    final String command = "bash";
+    final String compileX86 = "./helper-scripts/compile-x86.sh";
+    
+    /* execute the shell script in a unix process that inheirt from the current environment */
+    Runtime.getRuntime().exec(new String[] { command, compileX86 });
 }
 
 library {

--- a/jme3-alloc-native/build.gradle
+++ b/jme3-alloc-native/build.gradle
@@ -21,8 +21,13 @@ task copyNatives(type: Copy) {
 }
 
 task compileX86() {
-    final String command = "bash";
+    String command = "bash";
     final String compileX86 = "./helper-scripts/compile-x86.sh";
+    final String system = System.getProperty("os.name");
+    
+    if (system.equals("Windows")) {
+        command += ".exe";
+    }
     
     /* execute the shell script in a unix process that inheirt from the current environment */
     Runtime.getRuntime().exec(new String[] { command, compileX86 });


### PR DESCRIPTION
This PR fixes the windows-latest server cannot run the bash script by adding the command `bash` before the argument `./helper-scripts/compile-x86.sh`.