### PR TITLE
helper-scripts: added gcc-multilib install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,11 +67,7 @@ jobs:
             run: ./gradlew :jme3-alloc-native:build 
           
           - name: Install gcc-multilib 
-            run: | 
-              #!/bin/bash
-              if [[ `uname` == "Linux" ]]; then
-                  sudo apt-get install gcc-multilib
-              fi
+            run: bash ./helper-scripts/install-gcc-multilib.sh
           
           - name: Compiling x86 on ${{ matrix.os }}
             run: ./gradlew :jme3-alloc-native:compileX86

--- a/helper-scripts/install-gcc-multilib.sh
+++ b/helper-scripts/install-gcc-multilib.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [[ `uname` == "Linux" ]]; then
+  sudo apt-get install gcc-multilib
+fi


### PR DESCRIPTION
### This PR adds the following: 
- [x] Gcc multilib install script for linux to enable x86 binaries export.
- [x] Modified github workflow file to call the script. 