### PR TITLE
jme3-alloc/build.gradle: manipulate the project javadoc task to website

### DIFF
--- a/.github/workflows/doc-website.yml
+++ b/.github/workflows/doc-website.yml
@@ -34,9 +34,7 @@ jobs:
         run: chmod +rwx ./gradlew && ./gradlew :jme3-alloc:generateJavadocJar
 
       - name: Move javadocs to the deployment folder 'website'
-        run: | 
-          mv -v ./jme3-alloc/build/docs/javadoc ./website/javadoc/
-          ls -aR ./website/javadoc/
+        run: ./gradlew :jme3-alloc:manipulateJavadocForWebsite
           
       - name: Setup Doxygen
         run: sudo apt-get install doxygen

--- a/helper-scripts/abstract/abstract-move-files.sh
+++ b/helper-scripts/abstract/abstract-move-files.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function move() {
+    local src=$1
+    local dest=$2
+
+    mv -uv $src $dest 
+
+    return $?
+}

--- a/helper-scripts/project-impl/generate-native-doc.sh
+++ b/helper-scripts/project-impl/generate-native-doc.sh
@@ -8,7 +8,7 @@ version=${1}
 
 function generateNativeDoc1() {
     # generate native docuemnation using a doxygen config file to an output directory
-    generateNativeDoc "${website_dir}/${config}" "${website_dir}/${module}-${version}"
+    generateNativeDoc "${website_dir}/${config}" "${website_dir}/${native_module}-${version}"
     return $?
 }
 

--- a/helper-scripts/project-impl/move-javadoc.sh
+++ b/helper-scripts/project-impl/move-javadoc.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source "./helper-scripts/abstract/abstract-move-files.sh"
+source "./helper-scripts/project-impl/variables.sh"
+
+# get the version of the generated documentation from the command-line args
+version=${1}
+
+##
+# Moves the generated javadocs to the deployment folder.
+##
+function moveJavadoc() {
+    move "${javadoc}/" "${website_dir}/${java_module}-${version}"
+}
+
+moveJavadoc

--- a/helper-scripts/project-impl/variables.sh
+++ b/helper-scripts/project-impl/variables.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
-module="jme3-alloc-native"
 lib="libjmealloc"
 
-# specify the website directory to generate config and docs from the root folder
+# Website Stuff
+# ---------------------
+native_module="jme3-alloc-native"
+java_module="jme3-alloc"
 website_dir="./website"
 config="native-doc-config"
+javadoc="./jme3-alloc/build/docs/javadoc"
+# ---------------------
 
 native_sources="./${module}/src/lib/"
 native_headers="./${module}/src/include/"
 output="./${module}/build/lib"
 
-gcc=`which gcc`
+gcc=$(which gcc)
 compiler_optionsX86="-shared -m32 -g0 -s"
 compiler_optionsX86_debug="-shared -m32 -g3 -D__ENABLE_DEBUG_LOGGER -D__ENABLE_LOGGER"
 

--- a/jme3-alloc/build.gradle
+++ b/jme3-alloc/build.gradle
@@ -7,6 +7,7 @@
  */
 
 import com.jme3.build.util.JarMetadata;
+import com.jme3.build.UnixScriptRunner;
 
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
@@ -39,6 +40,11 @@ tasks.register("android") {
 
 tasks.register("desktop") {
     JarMetadata.TARGET.setData("desktop")
+}
+
+tasks.register("manipulateJavadocForWebsite", UnixScriptRunner) {
+   scriptArgs = new String[] { JarMetadata.VERSION.getData() }
+   script = "./helper-scripts/project-impl/move-javadoc.sh"
 }
 
 tasks.withType(JavaCompile) { // compile-time options [javac <options> <sources>]


### PR DESCRIPTION
## This PR adds the following:
- [x] Abstract move-file script at `./helper-scripts/abstract`.
- [x] Project move-javadoc script at `./helper-scripts/project-impl`.

## This PR modifies the following: 
- [x] `./jme3-alloc/build.gradle`: to add a Gradle task that manipulates the generated javadoc files from the `build/docs` folder to the website deployment folder renaming the root doc directory to `jme3-alloc-${version}`.
- [x] `.github/workflows/doc-website.yml`: to manipulate the generated javadoc files to the website deployment folder. 