### PR TITLE
API: use abstract `Buffer` instead of `ByteBuffer`

### DIFF
--- a/jme3-alloc/src/main/java/com/jme3/alloc/NativeBufferAllocator.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/NativeBufferAllocator.java
@@ -31,6 +31,7 @@
  */
 package com.jme3.alloc;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import com.jme3.alloc.util.NativeBufferUtils;
 
@@ -52,7 +53,7 @@ public final class NativeBufferAllocator {
      * @return a new direct byte buffer object of capacity [capacity] in bytes
      * @see com.jme3.alloc.util.NativeBufferUtils#clearAlloc(long)
      */
-    public static ByteBuffer createDirectByteBuffer(final long capacity) {
+    public static ByteBuffer allocate(final long capacity) {
         return NativeBufferUtils.clearAlloc(capacity);
     }
     
@@ -60,9 +61,9 @@ public final class NativeBufferAllocator {
      * Releases the memory of a direct buffer using a buffer object reference.
      *
      * @param buffer the buffer reference to release its memory.
-     * @see com.jme3.alloc.util.NativeBufferUtils#destroy(java.nio.ByteBuffer)
+     * @see com.jme3.alloc.util.NativeBufferUtils#destroy(java.nio.Buffer)
      */
-    public static void releaseDirectByteBuffer(final ByteBuffer buffer) {
+    public static void release(final Buffer buffer) {
         NativeBufferUtils.destroy(buffer);
     }
 }

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeBufferUtils.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeBufferUtils.java
@@ -32,6 +32,7 @@
 package com.jme3.alloc.util;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import com.jme3.alloc.util.loader.NativeBinaryLoader;
 
@@ -107,11 +108,11 @@ public final class NativeBufferUtils {
     /**
      * Frees a buffer previously allocated by {@link NativeBufferUtils#memoryAlloc(long)} and destroys (nullifies) the memory reference. 
      * 
-     * @param buffer a {@link java.nio.ByteBuffer} to destroy
+     * @param buffer a {@link java.nio.Buffer} to destroy
      * @see NativeBufferUtils#memoryAlloc(long)
      * @see NativeBufferUtils#clearAlloc(long)
      */
-    public static native void destroy(final ByteBuffer buffer);
+    public static native void destroy(final Buffer buffer);
 
     /**
      * Retrieves a memory address of a buffer previously allocated by {@link NativeBufferUtils#memoryAlloc(long)} in integers.


### PR DESCRIPTION
This PR fixes the incompatibility exception reported on the forums.