### PR TITLE
worflows/build-deploy.yml: removed 'prereleased' trigger

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -6,7 +6,7 @@ name: Build and deploy jme-alloc
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
   release:
-    types: [published, prereleased]
+    types: [published]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
This PR removes the `prereleased` on-release trigger event type to avoid duplicate workflow triggers for pre-release packages.