### PR TITLE
Mac-OS-binary: renamed `dylb` to `dylib`

### DIFF
--- a/helper-scripts/abstract/abstract-compile.sh
+++ b/helper-scripts/abstract/abstract-compile.sh
@@ -45,7 +45,7 @@ function compile() {
     local jni_headers0="${java_home}/include"
     
     if [[ `uname` == "Darwin" ]]; then 
-        local shared_lib="${output_lib}.dylb"
+        local shared_lib="${output_lib}.dylib"
         local jni_headers1="${jni_headers0}/darwin"
     elif [[ `uname` == "Linux" ]]; then 
         local shared_lib="${output_lib}.so"

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeDynamicLibrary.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeDynamicLibrary.java
@@ -50,12 +50,12 @@ public enum NativeDynamicLibrary {
     /**
      * Represents a mac x86 binary with 64-bit instruction set.
      */
-    MAC_x86_64("lib/macos/x86-64", "lib" + LibraryInfo.LIBRARY.getBaseName() + ".dylb"),
+    MAC_x86_64("lib/macos/x86-64", "lib" + LibraryInfo.LIBRARY.getBaseName() + ".dylib"),
 
     /**
      * Represents a mac x86 binary with 32-bit instruction set.
      */
-    MAC_x86("lib/macos/x86", "lib" + LibraryInfo.LIBRARY.getBaseName() + ".dylb"),
+    MAC_x86("lib/macos/x86", "lib" + LibraryInfo.LIBRARY.getBaseName() + ".dylib"),
 
     /**
      * Represents a windows x86 binary with 64-bit instruction set.


### PR DESCRIPTION
## This PR modifies the following:
- [x] `./helper-scripts/abstract/abstract-compile.sh`: renamed the `dylb` extension to `dylib`.
- [x] `com/jme3/alloc/util/loader/NativeDynamicLibrary.java`: renamed the `dylb` extension to `dylib`.