### PR TITLE
NativeBinaryLoader: proper logging through JUL

### DIFF
--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeBufferUtils.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeBufferUtils.java
@@ -43,7 +43,7 @@ import com.jme3.alloc.util.loader.NativeBinaryLoader;
 public final class NativeBufferUtils {
 
     static {
-        NativeBinaryLoader.quickLoadLibrary();
+        NativeBinaryLoader.loadLibraryIfEnabled();
     }
 
     private NativeBufferUtils() {

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeBufferUtils.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeBufferUtils.java
@@ -31,7 +31,6 @@
  */
 package com.jme3.alloc.util;
 
-import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import com.jme3.alloc.util.loader.NativeBinaryLoader;
@@ -44,7 +43,7 @@ import com.jme3.alloc.util.loader.NativeBinaryLoader;
 public final class NativeBufferUtils {
 
     static {
-        loadNativeBinary();
+        NativeBinaryLoader.quickLoadLibrary();
     }
 
     private NativeBufferUtils() {
@@ -116,16 +115,4 @@ public final class NativeBufferUtils {
      * @return a 32-bit or 64-bit integer (depending on the architecture) representing the memory address of the specified buffer
      */
     public static native long getMemoryAdress(final ByteBuffer buffer);
-    
-    private static void loadNativeBinary() {
-        if (!NativeBinaryLoader.isAutoLoad()) {
-            return;
-        }
-        try {
-            /* extracts and loads the system specific library */
-            NativeBinaryLoader.loadLibrary();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
 }

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeErrno.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeErrno.java
@@ -41,7 +41,7 @@ import com.jme3.alloc.util.loader.NativeBinaryLoader;
 public final class NativeErrno {
 
     static {
-        NativeBinaryLoader.quickLoadLibrary();
+        NativeBinaryLoader.loadLibraryIfEnabled();
     }
 
     private NativeErrno() {

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeErrno.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/NativeErrno.java
@@ -31,7 +31,6 @@
  */
 package com.jme3.alloc.util;
 
-import java.io.IOException;
 import com.jme3.alloc.util.loader.NativeBinaryLoader;
 
 /**
@@ -42,12 +41,7 @@ import com.jme3.alloc.util.loader.NativeBinaryLoader;
 public final class NativeErrno {
 
     static {
-        try {
-            /* extracts and loads the system specific library if it's not been loaded before */
-            NativeBinaryLoader.loadLibrary();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        NativeBinaryLoader.quickLoadLibrary();
     }
 
     private NativeErrno() {

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
@@ -36,6 +36,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.lang.UnsatisfiedLinkError;
 import com.jme3.alloc.util.NativeBufferUtils;
 
@@ -46,11 +48,28 @@ import com.jme3.alloc.util.NativeBufferUtils;
  */
 public final class NativeBinaryLoader {
     
+    private static final Logger LOGGER = Logger.getLogger(NativeBinaryLoader.class.getName());
     private static final ReentrantLock LOCK = new ReentrantLock();
     private static final int EOF = -1;
     private static boolean autoLoad = true;
 
     private NativeBinaryLoader() {
+    }
+
+    /**
+     * Extracts and loads the variant specific binary from the output jar, handling the error messages, 
+     * guarded by the {@link NativeBinaryLoader#isAutoLoad()}.
+     */
+    public static void quickLoadLibrary() {
+        if (!NativeBinaryLoader.isAutoLoad()) {
+            return;
+        }
+        try {
+            /* extracts and loads the system specific library */
+            NativeBinaryLoader.loadLibrary();
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Binary Not Found!", e);
+        }
     }
 
     /**

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
@@ -40,6 +40,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.lang.UnsatisfiedLinkError;
 import com.jme3.alloc.util.NativeBufferUtils;
+import com.jme3.alloc.util.NativeErrno;
 
 /**
  * Helper utility for loading native binaries.
@@ -94,7 +95,7 @@ public final class NativeBinaryLoader {
      * Default value is [true].
      * 
      * @param isAutoLoad true to auto-extract and load the native binary dynamically, false otherwise.
-     * @see NativeBufferUtils#loadNativeBinary()
+     * @see NativeBinaryLoader#quickLoadLibrary()
      */
     public static void setAutoLoad(boolean isAutoLoad) {
         NativeBinaryLoader.autoLoad = isAutoLoad;
@@ -102,10 +103,11 @@ public final class NativeBinaryLoader {
 
     /**
      * Tests whether the native-binary will be auto-extracted and loaded when the
-     * class initializer of {@link NativeBufferUtils} is called. Default value is [true].
+     * class initializer of {@link NativeBufferUtils} or {@link NativeErrno} is called. 
+     * Default value is [true].
      * 
      * @return true if the native-binary is to be auto-extracted and loaded dynamically, false otherwise.
-     * @see NativeBufferUtils#loadNativeBinary()
+     * @see NativeBinaryLoader#quickLoadLibrary()
      */
     public static boolean isAutoLoad() {
         return autoLoad;

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
@@ -61,7 +61,7 @@ public final class NativeBinaryLoader {
      * Extracts and loads the variant specific binary from the output jar, handling the error messages, 
      * guarded by the {@link NativeBinaryLoader#isAutoLoad()}.
      */
-    public static void quickLoadLibrary() {
+    public static void loadLibraryIfEnabled() {
         if (!NativeBinaryLoader.isAutoLoad()) {
             return;
         }

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
@@ -95,7 +95,7 @@ public final class NativeBinaryLoader {
      * Default value is [true].
      * 
      * @param isAutoLoad true to auto-extract and load the native binary dynamically, false otherwise.
-     * @see NativeBinaryLoader#quickLoadLibrary()
+     * @see NativeBinaryLoader#loadLibraryIfEnabled()
      */
     public static void setAutoLoad(boolean isAutoLoad) {
         NativeBinaryLoader.autoLoad = isAutoLoad;
@@ -107,7 +107,7 @@ public final class NativeBinaryLoader {
      * Default value is [true].
      * 
      * @return true if the native-binary is to be auto-extracted and loaded dynamically, false otherwise.
-     * @see NativeBinaryLoader#quickLoadLibrary()
+     * @see NativeBinaryLoader#loadLibraryIfEnabled()
      */
     public static boolean isAutoLoad() {
         return autoLoad;

--- a/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
+++ b/jme3-alloc/src/main/java/com/jme3/alloc/util/loader/NativeBinaryLoader.java
@@ -63,6 +63,7 @@ public final class NativeBinaryLoader {
      */
     public static void loadLibraryIfEnabled() {
         if (!NativeBinaryLoader.isAutoLoad()) {
+            LOGGER.log(Level.WARNING, "Stock Jme3-alloc-NativeBinaryLoader is not enabled!");
             return;
         }
         try {


### PR DESCRIPTION
## This PR modifies the following:
- [x] `com/jme3/alloc/util/loader/NativeBinaryLoader.java`: added `quickLoadLibrary()` method to handle the loading and to properly log error messages internally through JUL.
- [x] `com/jme3/alloc/util/NativeBufferUtils.java` and `com/jme3/alloc/util/NativeErrno.java`: call the `NativeBinaryLoader#quickLoadLibrary()` in the static class initializers `<clinit>`.
