### PR TITLE
Gradle-builds: removed guava-jre

### DIFF
--- a/jme3-alloc-examples/build.gradle
+++ b/jme3-alloc-examples/build.gradle
@@ -123,8 +123,5 @@ task createJar(type : Jar, dependsOn : copyLibs){
 }
 
 dependencies {
-    // This dependency is used by the application.
-    implementation 'com.google.guava:guava:31.1-jre'
-    
     implementation files("../jme3-alloc/build/libs/${dependencyName}")
 }

--- a/jme3-alloc/build.gradle
+++ b/jme3-alloc/build.gradle
@@ -70,7 +70,4 @@ jar { // assemble jar options [java -jar]
 dependencies {
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
-
-    // This dependency is used by the application.
-    implementation 'com.google.guava:guava:31.1-jre'
 }


### PR DESCRIPTION
This PR removes the unused implementations of guava-jre dependency.